### PR TITLE
Changed Buffer's deprecated constructor usage

### DIFF
--- a/integration.js
+++ b/integration.js
@@ -77,7 +77,7 @@ function IntegrationClient (baseUrl, applicationId, applicationKey, context) {
   this.defaults = url.parse(baseUrl)
   this.defaults.pathname = this.defaults.pathname.replace(/\/$/, '')
   this.applicationId = applicationId
-  this.hmacKey = new Buffer(applicationKey, 'hex')
+  this.hmacKey = Buffer.from(applicationKey, 'hex')
   this.context = context || {}
 }
 
@@ -163,7 +163,7 @@ IntegrationClient.prototype.request = function (method, path, payload, callback)
   })
 
   if (payload) {
-    var buff = new Buffer(JSON.stringify(payload))
+    var buff = Buffer.from(JSON.stringify(payload))
     var hmac = crypto.createHmac('md5', this.hmacKey);
     hmac.write(buff);
     hmac.end()


### PR DESCRIPTION
We should not use `Buffer` constructor anymore: https://nodejs.org/api/deprecations.html#deprecations_dep0005_buffer_constructor

It raises a deprecation warning and will be discarded completely in the future.
At the moment I just change the usage of the constructor to call the recommended `Buffer.from(...)` 

@mindreframer @aungerh @fmoeckel
What do you think we should have a fallback for users using node in a version < 5.10.0 (where this `Buffer.from` was introduced)? Or should we state that we drop support in earlier versions?